### PR TITLE
Configure allstar org wide policy

### DIFF
--- a/allstar.yaml
+++ b/allstar.yaml
@@ -1,0 +1,2 @@
+optConfig:
+  optOutStrategy: true

--- a/security.yaml
+++ b/security.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optOutStrategy: true
+action: issue


### PR DESCRIPTION
Configures the org level allstar policies - 
 - Sets the `optConfig` to `optOutStrategy` - meaning all repos under this org will be subject to the policies unless explicitly opted out.
 - Enables the security policy for all repos - this will check for existence of a `SECURITY.md` file containing the security policy for the repo, if the org wide security policy is not set. Allstar app will create an issue against the repo if missing. The issue will automatically close once the file is found. 